### PR TITLE
1000 vs i.length

### DIFF
--- a/_benchmarks/prueba-vs-prueba-2.md
+++ b/_benchmarks/prueba-vs-prueba-2.md
@@ -2,12 +2,13 @@
 title: Prueba vs prueba 2
 setup: |
   var a = 0;
-  var i = 1000;
+  var i = 0;
+  var length = 1000;
 tests:
   -
     name: Prueba
     code: |
-      for (i = 0; i<i.length; i++){
+      for (i = 0; i<length; i++){
       a = a + i;
       }
   -


### PR DESCRIPTION
This doesn't work, i.length will always be 4. This benchmark is not balanced.

I think the creator wanted to test a int vs a int inside a var.
