### PR TITLE
Update concat-vs-push.md

### DIFF
--- a/_benchmarks/concat-vs-push.md
+++ b/_benchmarks/concat-vs-push.md
@@ -16,8 +16,6 @@ tests:
   -
     name: push
     code: |
-      anotherArray.forEach(function(item) {
-        someBigArray.push(anotherArray);
-      })
+      Array.prototype.push.apply(someBigArray, anotherArray);
 ---
 


### PR DESCRIPTION
I believe the .forEach was causing huge lags in comparison. The Array.prototype.push.apply should normalize that a bit.